### PR TITLE
Refactor MAST download process to run sequentially and improve error logging

### DIFF
--- a/hst123/_pipeline.py
+++ b/hst123/_pipeline.py
@@ -1791,9 +1791,9 @@ class hst123(object):
         self.fix_hdu_wcs_keys(image, change_keys, ref_url)
         self.fix_idcscale(image)
         return True
-    except Exception:
+    except Exception as exc:
         error = 'Failed to update WCS for image {file}'
-        log.error(error.format(file=image))
+        log.error("%s: %s", error.format(file=image), exc)
         return None
 
   # ---------------------------------------------------------------------------
@@ -2567,8 +2567,10 @@ class hst123(object):
     Staging always lives under *work_dir* so ``mastDownload`` is not created in an
     unrelated shell current directory.
 
-    When multiple files need downloading, fetches run in parallel (thread pool)
-    with worker count ``min(--max-cores, number of files)``.
+    Downloads run **sequentially**. ``Observations.download_products`` (astroquery)
+    is not thread-safe; parallel calls caused intermittent ``I/O operation on closed
+    file`` errors and staging-directory races (``[Errno 17] File exists``).
+    ``--max-cores`` still applies to drizzle/DOLPHOT parallelism elsewhere.
     """
     if not productlist:
         log.error('Product list is empty. Cannot download files.')
@@ -2614,26 +2616,19 @@ class hst123(object):
         pending.append((i, prod, filename))
 
     n_pending = len(pending)
-    opt = getattr(self, "options", None)
-    args = opt.get("args") if opt else None
-    mc = getattr(args, "drizzle_num_cores", None) if args else None
-    if mc is None:
-        mc = settings.default_astrodrizzle_cores()
-    max_workers = max(1, min(int(mc), n_pending) if n_pending else 1)
 
     if n_pending:
         log.info(
-            "MAST download: fetching %i file(s) with up to %i thread(s) "
-            "(--max-cores).",
+            "MAST download: fetching %i file(s) sequentially (astroquery is not "
+            "safe for parallel downloads).",
             n_pending,
-            max_workers,
         )
         items = [
             (i, prod, filename, n, mast_staging_parent)
             for i, prod, filename in pending
         ]
-        with ThreadPoolExecutor(max_workers=max_workers) as pool:
-            pool.map(self._mast_download_one_product_row, items)
+        for it in items:
+            self._mast_download_one_product_row(it)
 
     # Remove astroquery staging under work-dir (not the shell cwd when --work-dir is set)
     if os.path.isdir(mast_download_tree):

--- a/tests/test_pipeline_mast_download.py
+++ b/tests/test_pipeline_mast_download.py
@@ -1,6 +1,6 @@
 """Unit tests for pipeline MAST download and archive path helpers."""
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from astropy.table import Table
@@ -38,11 +38,9 @@ def test_download_files_skips_existing_files_no_mast_call(hst123_instance, tmp_p
         }
     )
     with patch("hst123._pipeline.Observations.download_products") as mock_dl:
-        with patch("hst123._pipeline.ThreadPoolExecutor") as mock_tpe:
-            ok = hst.download_files(t, dest=str(dest), work_dir=str(tmp_path))
+        ok = hst.download_files(t, dest=str(dest), work_dir=str(tmp_path))
     assert ok is True
     mock_dl.assert_not_called()
-    mock_tpe.assert_not_called()
 
 
 def test_mast_download_one_product_row_moves_staged_file(hst123_instance, tmp_path):
@@ -85,12 +83,12 @@ def test_mast_download_one_product_row_logs_warning_on_failure(hst123_instance, 
     assert "MAST fail" in caplog.text
 
 
-def test_download_files_uses_thread_pool_max_workers_from_max_cores(
+def test_download_files_runs_one_worker_call_per_pending_file(
     hst123_instance, tmp_path
 ):
     _require_hst123()
     hst = hst123_instance
-    setattr(hst.options["args"], "drizzle_num_cores", 2)
+    setattr(hst.options["args"], "drizzle_num_cores", 6)
 
     t = Table(
         {
@@ -101,21 +99,11 @@ def test_download_files_uses_thread_pool_max_workers_from_max_cores(
     dest = tmp_path / "out"
     dest.mkdir()
 
-    mock_ctx = MagicMock()
-    mock_ctx.__enter__ = MagicMock(return_value=mock_ctx)
-    mock_ctx.__exit__ = MagicMock(return_value=None)
-    mock_ctx.map = MagicMock()
-
-    with patch("hst123._pipeline.ThreadPoolExecutor", return_value=mock_ctx) as mock_tpe:
+    with patch.object(hst, "_mast_download_one_product_row") as mock_one:
         with patch("hst123._pipeline.Observations.download_products"):
             hst.download_files(t, dest=str(dest), work_dir=str(tmp_path))
 
-    mock_tpe.assert_called_once_with(max_workers=2)
-    mock_ctx.map.assert_called_once()
-    map_args = mock_ctx.map.call_args[0]
-    assert map_args[0] == hst._mast_download_one_product_row
-    items = map_args[1]
-    assert len(items) == 3
+    assert mock_one.call_count == 3
 
 
 def test_archive_path_for_product_acs_wfc(hst123_instance, tmp_path):


### PR DESCRIPTION
- Updated the download mechanism to run sequentially due to thread-safety issues with `astroquery`, preventing intermittent I/O errors.
- Enhanced error logging to include exception details when WCS updates fail, improving debugging capabilities.
- Revised unit tests to reflect the new sequential download behavior and ensure proper function calls without thread pool usage.